### PR TITLE
fix(android): correct DropInActivity theme for Braintree

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,6 @@
               android:launchMode="singleTask"
               android:theme="@style/bt_drop_in_activity_theme"
               tools:replace="android:theme"/>
-              android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
         <activity android:name="com.braintreepayments.api.ThreeDSecureActivity"
               android:theme="@style/Theme.AppCompat.Light"
               android:exported="true"/>


### PR DESCRIPTION
## Summary
- fix Braintree DropInActivity manifest entry

## Testing
- `gradle assembleDebug` *(fails: /workspace/Quicky-Tasks/android/local.properties (No such file or directory))*
- `pod --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689be581d0388331826b73a66ad1c63c