### PR TITLE
fix(android): override ThreeDSecureActivity theme

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
               tools:replace="android:theme"/>
          <activity android:name="com.braintreepayments.api.ThreeDSecureActivity"
                android:exported="true"
-               android:theme="@style/Theme.AppCompat.Light"
+               android:theme="@style/Theme.Translucent.NoTitleBar.Fullscreen"
                tools:replace="android:theme"/>
 
         <!-- Main Activity Flutter -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,10 +33,10 @@
               android:launchMode="singleTask"
               android:theme="@style/bt_drop_in_activity_theme"
               tools:replace="android:theme"/>
-              android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
-        <activity android:name="com.braintreepayments.api.ThreeDSecureActivity"
-              android:theme="@style/Theme.AppCompat.Light"
-              android:exported="true"/>
+         <activity android:name="com.braintreepayments.api.ThreeDSecureActivity"
+               android:exported="true"
+               android:theme="@style/Theme.AppCompat.Light"
+               tools:replace="android:theme"/>
 
         <!-- Main Activity Flutter -->
         <activity android:name=".MainActivity" 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -6,6 +6,7 @@ platform :ios, '14.0.0'
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 # Caminho para o projeto Flutter
+flutter_root = File.expand_path('..', __dir__)
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
 flutter_ios_podfile_setup

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,9 +5,13 @@ platform :ios, '14.0.0'
 # Desativando as estatísticas do CocoaPods (opcional, mas pode melhorar o tempo de build)
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
-# Caminho para o projeto Flutter
-flutter_root = File.expand_path('..', __dir__)
-require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+# Caminho para o SDK do Flutter
+flutter_root = ENV['FLUTTER_ROOT'] || File.expand_path('..', __dir__)
+podhelper_path = File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+unless File.exist?(podhelper_path + '.rb')
+  raise "Não foi possível localizar o podhelper do Flutter em #{podhelper_path}. Defina a variável de ambiente FLUTTER_ROOT para o diretório do SDK do Flutter."
+end
+require podhelper_path
 
 flutter_ios_podfile_setup
 


### PR DESCRIPTION
## Summary
- override Braintree ThreeDSecureActivity theme to bypass manifest merge conflict

## Testing
- `pod --version --allow-root`
- `flutter build apk --release` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_b_689be581d0388331826b73a66ad1c63c