### PR TITLE
Use Authorize.Net SDK for nonce generation

### DIFF
--- a/lib/components/cardplacehokder_widget.dart
+++ b/lib/components/cardplacehokder_widget.dart
@@ -694,7 +694,8 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
                   logFirebaseEvent('CARDPLACEHOKDER_COMP_BUY_BTN_ON_TAP');
                   logFirebaseEvent('Button_custom_action');
                   _model.rapydPayment = await actions.generateAuthorizeNetNonce(
-                    'sandbox_ck9vkcgg_brg8dhjg5tqpw496\t',
+                    'sandbox_api_login_id',
+                    'sandbox_ck9vkcgg_brg8dhjg5tqpw496',
                     _model.textController1.text,
                     functions.retirepartesdadata(
                         _model.textController2.text, 'month')!,
@@ -705,6 +706,7 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
                     'https://us-central1-quick-b108e.cloudfunctions.net/baintreePayment',
                     _model.textController4.text,
                     'Quicky QS Tokens',
+                    'test',
                   );
                   logFirebaseEvent('Button_bottom_sheet');
                   await showModalBottomSheet(

--- a/lib/custom_code/actions/generate_authorize_net_nonce.dart
+++ b/lib/custom_code/actions/generate_authorize_net_nonce.dart
@@ -9,17 +9,17 @@ import 'package:flutter/material.dart';
 // Begin custom action code
 // DO NOT REMOVE OR MODIFY THE CODE ABOVE!
 
-import 'package:braintree_flutter_plus/braintree_flutter_plus.dart';
+import 'package:authorize_net_sdk_plugin/authorize_net_sdk_plugin.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
-/// Gera o nonce do cartão no cliente e conclui o pagamento no seu backend
-/// (um único endpoint para GET=token e POST=checkout).
+/// Gera o nonce do cartão no cliente via Authorize.Net e conclui o pagamento no
+/// seu backend (POST único).
 ///
-/// tokenizationKey: opcional (fallback se falhar pegar clientToken)
-/// backendUrl: URL ÚNICA da sua Cloud Function (mesmo endpoint p/ GET e POST)
+/// backendUrl: URL ÚNICA da sua Cloud Function (mesmo endpoint p/ checkout)
 Future<String> generateAuthorizeNetNonce(
-  String tokenizationKey,
+  String apiLoginId,
+  String clientKey,
   String cardNumber,
   String expirationMonth,
   String expirationYear,
@@ -28,6 +28,7 @@ Future<String> generateAuthorizeNetNonce(
   String backendUrl,
   String displayName,
   String billingDescription,
+  String environment,
 ) async {
   try {
     // --- Sanitização & validação ---
@@ -45,36 +46,23 @@ Future<String> generateAuthorizeNetNonce(
       throw Exception('Valor inválido (use > 0 com até 2 casas decimais).');
     }
 
-    // --- 1) Pega client token do backend (GET no MESMO endpoint) ---
-    String authorization = await _fetchClientToken(backendUrl);
-    if (authorization.isEmpty) {
-      // fallback: tokenizationKey (menos poderoso que clientToken)
-      authorization = tokenizationKey.trim();
-    }
-    if (authorization.isEmpty) {
-      throw Exception(
-          'Falha ao obter autorização do Braintree (clientToken/tokenizationKey).');
+    // --- 1) Inicializa o plugin e verifica se está pronto ---
+    final plugin = AuthorizeNetSdkPlugin();
+    final ready = await plugin.isReady();
+    if (!ready) {
+      throw Exception('SDK não está pronto para gerar nonce.');
     }
 
-    // --- 2) Tokeniza o cartão (gera NONCE) ---
-    final creditCardRequest = BraintreeCreditCardRequest(
+    // --- 2) Gera o nonce do cartão ---
+    final nonce = (await plugin.generateNonce(
+      apiLoginId: apiLoginId,
+      clientKey: clientKey,
       cardNumber: digitsOnly,
       expirationMonth: mm,
       expirationYear: yyyy,
-      cvv: cardCvv.trim(),
-      // 👇 O plugin PLUS pede amount aqui (usado p/ 3DS)
-      amount: normalizedAmount, // String com 2 casas decimais
-      // Se o seu pacote reclamar de tipo, troque para:
-      // amount: double.parse(normalizedAmount),
-      // (algumas forks tipam como double)
-    );
-
-    final tokenized = await Braintree.tokenizeCreditCard(
-      authorization,
-      creditCardRequest,
-    );
-
-    final nonce = (tokenized?.nonce ?? '').trim();
+      cardCode: cardCvv.trim(),
+      environment: environment,
+    ))?.trim() ?? '';
     if (nonce.isEmpty) {
       throw Exception('Falha ao gerar nonce do cartão.');
     }
@@ -116,20 +104,7 @@ Future<String> generateAuthorizeNetNonce(
     throw Exception('Erro ao processar pagamento: $e');
   }
 }
-
 // -------------------- Helpers --------------------
-
-Future<String> _fetchClientToken(String backendUrl) async {
-  try {
-    final r = await http.get(Uri.parse(backendUrl));
-    if (r.statusCode == 200) {
-      final data = jsonDecode(r.body) as Map<String, dynamic>;
-      final token = (data['clientToken'] ?? '').toString().trim();
-      return token;
-    }
-  } catch (_) {}
-  return '';
-}
 
 /// Retorna string com 2 casas decimais se válido, ou null se inválido/<=0
 String? _normalizeAmount(double amount) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   apple_maps_flutter: ^1.4.0
   audio_waveforms: ^1.0.6
   auto_size_text: 3.0.0
-  braintree_flutter_plus: 5.0.5
+  authorize_net_sdk_plugin: ^0.0.5
   cached_network_image: 3.4.1
   cached_network_image_platform_interface: 4.1.1
   cached_network_image_web: 1.3.1


### PR DESCRIPTION
## Summary
- replace Braintree plugin with Authorize.Net
- generate nonce through AuthorizeNetSdkPlugin and send to backend
- update dependency and widget call for new API

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cad8e18c08331b86e4089f0341512