### PR TITLE
Remove leftover Braintree configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
     defaultConfig {
         applicationId "com.nagazakisoftware.quick"
-        minSdkVersion 23       // Braintree pede 21+, aqui tá ok
+        minSdkVersion 23
         targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -10,7 +10,5 @@
 -dontwarn org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
 -keep class org.xmlpull.v1.** { *; }
 
--keep class com.braintreepayments.** { *; }
--dontwarn com.braintreepayments.**
 -keep class com.google.android.gms.wallet.** { *; }
 -dontwarn com.google.android.gms.**

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
   >
     <!-- Habilita Google Pay na Drop-in (opcional, mas recomendado se usar GPay) -->
     <meta-data android:name="com.google.android.gms.wallet.api.enabled" android:value="true"/>
-    <!-- Requer também configuração no painel do Braintree -->
     <activity android:name=".MainActivity" android:exported="true" android:launchMode="singleTop" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize">
       <meta-data android:name="io.flutter.embedding.android.NormalTheme" android:resource="@style/NormalTheme"/>
       <meta-data android:name="io.flutter.embedding.android.SplashScreenDrawable" android:resource="@drawable/launch_background"/>
@@ -31,14 +30,6 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="quicky" android:host="quicky.com"/>
-      </intent-filter>
-      <!-- 🔑 Braintree (Browser Switch / PayPal/Venmo) -->
-      <!-- IMPORTANTE: o scheme DEVE ser tudo minúsculo e seguir: <applicationId>.braintree -->
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW"/>
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="com.nagazakisoftware.quick.braintree"/>
       </intent-filter>
     </activity>
     <meta-data android:name="flutterEmbedding" android:value="2"/>


### PR DESCRIPTION
## Summary
- Remove Braintree-specific intent filter from AndroidManifest
- Drop Braintree ProGuard rules and keep minSdkVersion clean
- Checked authorize_net_sdk_plugin docs (no extra ProGuard or permissions needed)

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cad953da08331b566dea90c175460