### PR TITLE
Remove Braintree integration from iOS project

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -27,8 +27,6 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 # <<< ESSA LINHA PRECISA EXISTIR >>>
 flutter_ios_podfile_setup
 
-# Braintree/Flutter funcionam bem com frameworks estáticos
-use_frameworks! :linkage => :static
 # ⚠️ Não use 'use_modular_headers!' global aqui (só se algum pod específico pedir)
 
 target 'Runner' do
@@ -50,10 +48,6 @@ post_install do |installer|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
       # Xcode 15 toolchain
       config.build_settings['SWIFT_VERSION'] = '5.9'
-      # Não tratar warnings como erro (Braintree/PayPal soltam depreciação)
-      config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'NO'
-      config.build_settings['SWIFT_TREAT_WARNINGS_AS_ERRORS'] = 'NO'
-      config.build_settings['OTHER_CFLAGS'] = '$(inherited) -Wno-deprecated-declarations'
     end
   end
 end

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,7 +1,5 @@
 import UIKit
 import Flutter
-import BraintreeCore
-
 @main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
@@ -10,22 +8,6 @@ import BraintreeCore
   ) -> Bool {
     // Registrar plugins Flutter
     GeneratedPluginRegistrant.register(with: self)
-    
-    // Configura o esquema da URL para o callback do Braintree PayPal
-    BTAppContextSwitcher.setReturnURLScheme("com.nagazakisoftware.quick.payments") // <--- coloque seu CFBundleURLSchemes aqui
-    
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
-
-  // Método para tratar a abertura da URL de callback do PayPal/Braintree
-  override func application(
-    _ app: UIApplication,
-    open url: URL,
-    options: [UIApplication.OpenURLOptionsKey : Any] = [:]
-  ) -> Bool {
-    if BTAppContextSwitcher.handleOpenURL(url) {
-      return true
-    }
-    return super.application(app, open: url, options: options)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -20,7 +20,7 @@
     <string>$(FLUTTER_BUILD_NAME)</string>
     <key>CFBundleSignature</key>
     <string>????</string>
-    <!-- URL Schemes (FlutterFlow, Quicky e Braintree) -->
+    <!-- URL Schemes (FlutterFlow e Quicky) -->
     <key>CFBundleURLTypes</key>
     <array>
       <!-- FlutterFlow / Google Sign-In -->
@@ -41,17 +41,6 @@
         <key>CFBundleURLSchemes</key>
         <array>
           <string>quicky</string>
-        </array>
-      </dict>
-      <!-- Braintree return URL -->
-      <dict>
-        <key>CFBundleTypeRole</key>
-        <string>Editor</string>
-        <key>CFBundleURLName</key>
-        <string>com.nagazakisoftware.quick.payments</string>
-        <key>CFBundleURLSchemes</key>
-        <array>
-          <string>com.nagazakisoftware.quick.payments</string>
         </array>
       </dict>
     </array>


### PR DESCRIPTION
## Summary
- remove Braintree plugin hooks from `AppDelegate` and Info.plist
- streamline iOS Podfile by dropping Braintree-specific configuration

## Testing
- `pod install --allow-root` *(fails: `/workspace/Quicky-Tasks/ios/Flutter/Generated.xcconfig must exist`)*

------
https://chatgpt.com/codex/tasks/task_b_689cad9988208331b37da5aa753e9d46