### PR TITLE
Configure CardinalCommerce repository credentials

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -13,7 +13,17 @@ pluginManagement {
         google()
         mavenCentral()
         maven { url = uri("https://storage.googleapis.com/download.flutter.io") }
-        maven { url = uri("https://cardinalcommerceprod.jfrog.io/artifactory/android") }
+        def cardinalUsername = System.getenv("CARDINAL_USERNAME")
+        def cardinalPassword = System.getenv("CARDINAL_PASSWORD")
+        maven {
+            url = uri("https://cardinalcommerceprod.jfrog.io/artifactory/android")
+            if (cardinalUsername && cardinalPassword) {
+                credentials {
+                    username = cardinalUsername
+                    password = cardinalPassword
+                }
+            }
+        }
         gradlePluginPortal()
     }
 }
@@ -32,7 +42,17 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://storage.googleapis.com/download.flutter.io") }
-        maven { url = uri("https://cardinalcommerceprod.jfrog.io/artifactory/android") }
+        def cardinalUsername = System.getenv("CARDINAL_USERNAME")
+        def cardinalPassword = System.getenv("CARDINAL_PASSWORD")
+        maven {
+            url = uri("https://cardinalcommerceprod.jfrog.io/artifactory/android")
+            if (cardinalUsername && cardinalPassword) {
+                credentials {
+                    username = cardinalUsername
+                    password = cardinalPassword
+                }
+            }
+        }
         maven { url = uri("https://jitpack.io") }
     }
 }


### PR DESCRIPTION
## Summary
- allow Gradle to supply credentials for CardinalCommerce repository via environment variables

## Testing
- `flutter test` *(fails: command not found)*
- `cd android && ./gradlew tasks` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689d07a1e1d08331879e21f53ac7f2f0