### PR TITLE
feat: add Android home widget

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="quicky" android:host="quicky.com"/>
       </intent-filter>
+      <intent-filter>
+        <action android:name="es.antonborri.home_widget.action.LAUNCH" />
+      </intent-filter>
     </activity>
     <!-- ============================ -->
     <!-- Braintree: Drop-in + 3DS2   -->
@@ -52,5 +55,19 @@
     <!-- ============================ -->
     <!-- Usado pelo Flutter -->
     <meta-data android:name="flutterEmbedding" android:value="2"/>
+
+    <receiver android:name=".QuickyWidgetProvider" android:exported="true">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+      </intent-filter>
+      <meta-data android:name="android.appwidget.provider" android:resource="@xml/quicky_widget_provider" />
+    </receiver>
+
+    <receiver android:name="es.antonborri.home_widget.HomeWidgetBackgroundReceiver" android:exported="true">
+      <intent-filter>
+        <action android:name="es.antonborri.home_widget.action.BACKGROUND" />
+      </intent-filter>
+    </receiver>
+    <service android:name="es.antonborri.home_widget.HomeWidgetBackgroundService" android:permission="android.permission.BIND_JOB_SERVICE" android:exported="true"/>
   </application>
 </manifest>

--- a/android/app/src/main/kotlin/com/example/my_project/QuickyWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/example/my_project/QuickyWidgetProvider.kt
@@ -1,0 +1,44 @@
+package com.nagazakisoftware.quick
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.graphics.BitmapFactory
+import android.view.View
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+import java.net.URL
+
+class QuickyWidgetProvider : HomeWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences
+    ) {
+        appWidgetIds.forEach { widgetId ->
+            val views = RemoteViews(context.packageName, R.layout.quicky_widget_layout).apply {
+                val name = widgetData.getString("display_name", "")
+                setTextViewText(R.id.widget_display_name, name)
+
+                setTextViewText(R.id.widget_balance_value, widgetData.getString("saldo", ""))
+                setTextViewText(R.id.widget_next_task_value, widgetData.getString("nexttask", ""))
+                setTextViewText(R.id.widget_rating_value, widgetData.getString("rating", ""))
+
+                val photoUrl = widgetData.getString("photo_url", null)
+                if (photoUrl != null && photoUrl.isNotEmpty()) {
+                    try {
+                        val url = URL(photoUrl)
+                        val bmp = BitmapFactory.decodeStream(url.openConnection().getInputStream())
+                        setImageViewBitmap(R.id.widget_avatar, bmp)
+                    } catch (_: Exception) {
+                        setViewVisibility(R.id.widget_avatar, View.GONE)
+                    }
+                } else {
+                    setViewVisibility(R.id.widget_avatar, View.GONE)
+                }
+            }
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/res/layout/quicky_widget_layout.xml
+++ b/android/app/src/main/res/layout/quicky_widget_layout.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#b08c5f"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/widget_avatar"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:scaleType="centerCrop"
+            android:src="@mipmap/ic_launcher" />
+
+        <TextView
+            android:id="@+id/widget_display_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textStyle="bold"
+            android:textSize="18sp"
+            android:text="display_name" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="8dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/widget_balance_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Balance" />
+
+            <TextView
+                android:id="@+id/widget_balance_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="$0" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/widget_next_task_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Next task" />
+
+            <TextView
+                android:id="@+id/widget_next_task_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="--/--" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/widget_rating_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Rating" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <ImageView
+                    android:id="@+id/widget_rating_star"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:src="@android:drawable/btn_star_big_on" />
+
+                <TextView
+                    android:id="@+id/widget_rating_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:text="0" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/xml/quicky_widget_provider.xml
+++ b/android/app/src/main/res/xml/quicky_widget_provider.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="100dp"
+    android:updatePeriodMillis="86400000"
+    android:initialLayout="@layout/quicky_widget_layout"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/lib/home_widget/home_widget_service.dart
+++ b/lib/home_widget/home_widget_service.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:home_widget/home_widget.dart';
+
+class QuickyHomeWidgetService {
+  static const _provider = 'QuickyWidgetProvider';
+
+  static Future<void> update() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+
+    final doc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+    final data = doc.data();
+    if (data == null) return;
+
+    await HomeWidget.saveWidgetData<String>('display_name', data['display_name'] ?? '');
+    await HomeWidget.saveWidgetData<String>('photo_url', data['photo_url'] ?? '');
+    await HomeWidget.saveWidgetData<String>('saldo', (data['saldo'] ?? '').toString());
+    await HomeWidget.saveWidgetData<String>('nexttask', (data['nexttask'] ?? '').toString());
+    await HomeWidget.saveWidgetData<String>('rating', (data['rating'] ?? '').toString());
+
+    await HomeWidget.updateWidget(name: _provider);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,6 +118,7 @@ dependencies:
   html: 0.15.6
   http: 1.4.0
   http_parser: ^4.0.1
+  home_widget: 0.8.0
   image_picker: 1.1.2
   image_picker_android: 0.8.12+23
   image_picker_for_web: 3.0.6


### PR DESCRIPTION
## Summary
- add Android home-screen widget using `home_widget`
- fetch authenticated user's Firestore data for widget display
- register widget provider and resources

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e0ec4f7348331be06a9877124acd5