### PR TITLE
Configure widget extension principal class

### DIFF
--- a/ios/Quicky Widget/Info.plist
+++ b/ios/Quicky Widget/Info.plist
@@ -2,10 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
+        <key>NSExtension</key>
+        <dict>
+                <key>NSExtensionPointIdentifier</key>
+                <string>com.apple.widgetkit-extension</string>
+                <key>NSExtensionPrincipalClass</key>
+                <string>$(PRODUCT_MODULE_NAME).Quicky_Widget</string>
+                <key>NSExtensionAttributes</key>
+                <dict>
+                        <key>WidgetFamily</key>
+                        <array>
+                                <string>systemSmall</string>
+                                <string>systemMedium</string>
+                                <string>systemLarge</string>
+                                <string>systemExtraLarge</string>
+                        </array>
+                </dict>
+        </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add `NSExtensionPrincipalClass` to widget extension's `Info.plist`.
- Define `NSExtensionAttributes` with supported widget families.

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a09fa732bc8331b06334909d665058