### PR TITLE
Add Apple and Google Pay buttons via Braintree

### DIFF
--- a/lib/components/card_swipead_widget.dart
+++ b/lib/components/card_swipead_widget.dart
@@ -12,6 +12,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
+import 'package:braintree_native_ui/braintree_native_ui.dart';
 import 'card_swipead_model.dart';
 export 'card_swipead_model.dart';
 
@@ -29,6 +30,49 @@ class CardSwipeadWidget extends StatefulWidget {
 
 class _CardSwipeadWidgetState extends State<CardSwipeadWidget> {
   late CardSwipeadModel _model;
+  final _braintree = BraintreeNativeUi();
+
+  Future<void> _payWithGoogle(double amount) async {
+    const authorization = 'YOUR_TOKENIZATION_KEY_OR_CLIENT_TOKEN';
+    try {
+      final nonce = await _braintree.requestGooglePayPayment(
+        authorization: authorization,
+        amount: amount.toStringAsFixed(2),
+        currencyCode: 'USD',
+      );
+      if (nonce != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Google Pay nonce: $nonce')),
+        );
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Google Pay error: $e')),
+      );
+    }
+  }
+
+  Future<void> _payWithApple(double amount) async {
+    const authorization = 'YOUR_TOKENIZATION_KEY_OR_CLIENT_TOKEN';
+    try {
+      final nonce = await _braintree.requestApplePayPayment(
+        authorization: authorization,
+        merchantIdentifier: 'merchant.com.example',
+        countryCode: 'US',
+        currencyCode: 'USD',
+        amount: amount.toStringAsFixed(2),
+      );
+      if (nonce != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Apple Pay nonce: $nonce')),
+        );
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Apple Pay error: $e')),
+      );
+    }
+  }
 
   @override
   void setState(VoidCallback callback) {
@@ -913,6 +957,97 @@ class _CardSwipeadWidgetState extends State<CardSwipeadWidget> {
                                 ),
                               ),
                             ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: EdgeInsetsDirectional.fromSTEB(
+                          5.0, 8.0, 5.0, 0.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceAround,
+                        children: [
+                          Expanded(
+                            child: InkWell(
+                              onTap: () async {
+                                await _payWithApple(
+                                    containerTasksRecord.pagamentoPrecos);
+                              },
+                              child: Container(
+                                height: 50.0,
+                                decoration: BoxDecoration(
+                                  color: Colors.black,
+                                  borderRadius: BorderRadius.circular(8.0),
+                                ),
+                                child: Center(
+                                  child: Text(
+                                    'Apple Pay',
+                                    style: FlutterFlowTheme.of(context)
+                                        .bodyMedium
+                                        .override(
+                                          font: GoogleFonts.poppins(
+                                            fontWeight: FontWeight.w500,
+                                            fontStyle:
+                                                FlutterFlowTheme.of(context)
+                                                    .bodyMedium
+                                                    .fontStyle,
+                                          ),
+                                          color: FlutterFlowTheme.of(context)
+                                              .primaryBackground,
+                                          fontSize: 16.0,
+                                          letterSpacing: 0.0,
+                                          fontWeight: FontWeight.w500,
+                                          fontStyle:
+                                              FlutterFlowTheme.of(context)
+                                                  .bodyMedium
+                                                  .fontStyle,
+                                        ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                          SizedBox(width: 8.0),
+                          Expanded(
+                            child: InkWell(
+                              onTap: () async {
+                                await _payWithGoogle(
+                                    containerTasksRecord.pagamentoPrecos);
+                              },
+                              child: Container(
+                                height: 50.0,
+                                decoration: BoxDecoration(
+                                  color: Colors.white,
+                                  borderRadius: BorderRadius.circular(8.0),
+                                  border: Border.all(color: Colors.black),
+                                ),
+                                child: Center(
+                                  child: Text(
+                                    'Google Pay',
+                                    style: FlutterFlowTheme.of(context)
+                                        .bodyMedium
+                                        .override(
+                                          font: GoogleFonts.poppins(
+                                            fontWeight: FontWeight.w500,
+                                            fontStyle:
+                                                FlutterFlowTheme.of(context)
+                                                    .bodyMedium
+                                                    .fontStyle,
+                                          ),
+                                          color: FlutterFlowTheme.of(context)
+                                              .primaryText,
+                                          fontSize: 16.0,
+                                          letterSpacing: 0.0,
+                                          fontWeight: FontWeight.w500,
+                                          fontStyle:
+                                              FlutterFlowTheme.of(context)
+                                                  .bodyMedium
+                                                  .fontStyle,
+                                        ),
+                                  ),
+                                ),
+                              ),
+                            ),
                           ),
                         ],
                       ),


### PR DESCRIPTION
## Summary
- integrate braintree_native_ui for Apple Pay and Google Pay
- add helper methods and UI buttons to trigger payments

## Testing
- `flutter format lib/components/card_swipead_widget.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0a0495a508331b80ca8c81975a746