### PR TITLE
Fix WidgetKit Info.plist configuration

### DIFF
--- a/ios/Quicky Widget/Info.plist
+++ b/ios/Quicky Widget/Info.plist
@@ -6,8 +6,12 @@
   <dict>
     <key>NSExtensionPointIdentifier</key>
     <string>com.apple.widgetkit-extension</string>
+    <key>NSExtensionPrincipalClass</key>
+    <string>$(PRODUCT_MODULE_NAME).Quicky_WidgetBundle</string>
     <key>NSExtensionAttributes</key>
     <dict>
+      <key>WKAppBundleIdentifier</key>
+      <string>com.nagazakisoftware.quick</string>
       <key>WidgetFamily</key>
       <array>
         <string>systemSmall</string>


### PR DESCRIPTION
## Summary
- define the widget principal class for the WidgetKit extension
- link the widget to the main app bundle identifier

## Testing
- ⚠️ `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a0c14f588c8331abde8685e7b491b7