### PR TITLE
Fix WidgetKit Info.plist configuration

### DIFF
--- a/ios/Quicky Widget/Info.plist
+++ b/ios/Quicky Widget/Info.plist
@@ -8,6 +8,8 @@
     <string>com.apple.widgetkit-extension</string>
     <key>NSExtensionAttributes</key>
     <dict>
+      <key>WKAppBundleIdentifier</key>
+      <string>com.nagazakisoftware.quick</string>
       <key>WidgetFamily</key>
       <array>
         <string>systemSmall</string>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -543,7 +543,7 @@
                                 CURRENT_PROJECT_VERSION = 1;
                                 ENABLE_USER_SCRIPT_SANDBOXING = YES;
                                 GCC_C_LANGUAGE_STANDARD = gnu17;
-                                GENERATE_INFOPLIST_FILE = YES;
+                                GENERATE_INFOPLIST_FILE = NO;
                                 INFOPLIST_FILE = "Quicky Widget/Info.plist";
                                 INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
                                 INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -585,7 +585,7 @@
                                 CURRENT_PROJECT_VERSION = 1;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+                                GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Quicky Widget/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -624,7 +624,7 @@
                                 CURRENT_PROJECT_VERSION = 1;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+                                GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Quicky Widget/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";


### PR DESCRIPTION
## Summary
- prevent Xcode from auto-generating widget Info.plist so disallowed NSExtensionPrincipalClass isn't reinserted

## Testing
- ⚠️ `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a0c14f588c8331abde8685e7b491b7