### PR TITLE
Fix WidgetKit Info.plist configuration

### DIFF
--- a/ios/Quicky Widget/Info.plist
+++ b/ios/Quicky Widget/Info.plist
@@ -2,12 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <key>CFBundleDisplayName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
   <key>NSExtension</key>
   <dict>
-    <key>NSExtensionPointIdentifier</key>
-    <string>com.apple.widgetkit-extension</string>
     <key>NSExtensionAttributes</key>
     <dict>
+      <key>WKAppBundleIdentifier</key>
+      <string>com.nagazakisoftware.quick</string>
       <key>WidgetFamily</key>
       <array>
         <string>systemSmall</string>
@@ -16,6 +34,8 @@
         <string>systemExtraLarge</string>
       </array>
     </dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.widgetkit-extension</string>
   </dict>
 </dict>
 </plist>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -543,7 +543,7 @@
                                 CURRENT_PROJECT_VERSION = 1;
                                 ENABLE_USER_SCRIPT_SANDBOXING = YES;
                                 GCC_C_LANGUAGE_STANDARD = gnu17;
-                                GENERATE_INFOPLIST_FILE = YES;
+                                GENERATE_INFOPLIST_FILE = NO;
                                 INFOPLIST_FILE = "Quicky Widget/Info.plist";
                                 INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
                                 INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -585,7 +585,7 @@
                                 CURRENT_PROJECT_VERSION = 1;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+                                GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Quicky Widget/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -624,7 +624,7 @@
                                 CURRENT_PROJECT_VERSION = 1;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+                                GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Quicky Widget/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";


### PR DESCRIPTION
## Summary
- prevent Xcode from auto-generating widget Info.plist so disallowed NSExtensionPrincipalClass isn't reinserted
- supply full Info.plist with standard bundle keys and WKAppBundleIdentifier linking to host app

## Testing
- ⚠️ `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a0c14f588c8331abde8685e7b491b7