### PR TITLE
Handle errors for Braintree 3DS payment flow

### DIFF
--- a/lib/components/cardplacehokder_widget.dart
+++ b/lib/components/cardplacehokder_widget.dart
@@ -773,31 +773,42 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
                 onPressed: () async {
                   logFirebaseEvent('CARDPLACEHOKDER_COMP_BUY_BTN_ON_TAP');
                   logFirebaseEvent('Button_custom_action');
-                  _model.rapydPayment =
-                      await actions.processBraintreeCard3DSNativeUI(
-                    'https://us-central1-quick-b108e.cloudfunctions.net/braintreePayment',
-                    widget.value!,
-                    currentUserEmail,
-                    _model.textController1.text,
-                    functions.retirepartesdadata(
-                        _model.textController2.text, 'month')!,
-                    functions.retirepartesdadata(
-                        _model.textController2.text, 'year')!,
-                    _model.textController3.text,
-                    functions.separartextoeescolherposicao(
-                        currentUserDisplayName, 0),
-                    functions.separartextoeescolherposicao(
-                        currentUserDisplayName, 1),
-                    '+348 3467-3478',
-                    'SDFSD',
-                    '',
-                    'Ariozona',
-                    'US',
-                    '92345',
-                    'US',
-                    'brg8dhjg5tqpw496',
-                    'ORDER-QUICKYQS',
-                  );
+                  try {
+                    _model.rapydPayment =
+                        await actions.processBraintreeCard3DSNativeUI(
+                      'https://us-central1-quick-b108e.cloudfunctions.net/braintreePayment',
+                      widget.value!,
+                      currentUserEmail,
+                      _model.textController1.text,
+                      functions.retirepartesdadata(
+                          _model.textController2.text, 'month')!,
+                      functions.retirepartesdadata(
+                          _model.textController2.text, 'year')!,
+                      _model.textController3.text,
+                      functions.separartextoeescolherposicao(
+                          currentUserDisplayName, 0),
+                      functions.separartextoeescolherposicao(
+                          currentUserDisplayName, 1),
+                      '+348 3467-3478',
+                      'SDFSD',
+                      '',
+                      'Ariozona',
+                      'US',
+                      '92345',
+                      'US',
+                      'brg8dhjg5tqpw496',
+                      'ORDER-QUICKYQS',
+                    );
+                  } catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text(
+                          'Error processing payment. Please try again.',
+                        ),
+                      ),
+                    );
+                    debugPrint('processBraintreeCard3DSNativeUI error: $e');
+                  }
 
                   safeSetState(() {});
                 },


### PR DESCRIPTION
## Summary
- wrap `processBraintreeCard3DSNativeUI` in try/catch
- display SnackBar on failure and log the error

## Testing
- `flutter format lib/components/cardplacehokder_widget.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0eb9783708331b480f9bf49110d4f