### PR TITLE
Fix missing semicolon in cardplacehokder initState

### DIFF
--- a/lib/components/cardplacehokder_widget.dart
+++ b/lib/components/cardplacehokder_widget.dart
@@ -219,7 +219,7 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
     _model.textFieldFocusNode10 ??= FocusNode();
 
     _model.textController11 ??= TextEditingController();
-    _model.textFieldFocusNode11 ??= FocusNode()
+    _model.textFieldFocusNode11 ??= FocusNode();
     _model.textController1Validator = (context, value) {
       if (value == null || value.isEmpty) {
         return 'Enter card number';


### PR DESCRIPTION
## Summary
- Add missing semicolon when initializing `_model.textFieldFocusNode11` in `CardplacehokderWidget`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a145f134a08331864df188759fd0f6