### PR TITLE
Add mounted checks before payment SnackBars

### DIFF
--- a/lib/components/cardplacehokder_widget.dart
+++ b/lib/components/cardplacehokder_widget.dart
@@ -107,10 +107,9 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
     } catch (e) {
       final message = 'Unable to obtain client token: $e';
       debugPrint(message);
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(message)));
-      }
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(message)));
       return;
     }
 
@@ -122,6 +121,7 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
       );
       if (nonce != null) {
         final result = await _createTransaction(nonce, amount);
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(result)),
         );
@@ -129,10 +129,9 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
     } catch (e) {
       final message = 'Google Pay error: $e';
       debugPrint(message);
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(message)));
-      }
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(message)));
     }
   }
 
@@ -143,10 +142,9 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
     } catch (e) {
       final message = 'Unable to obtain client token: $e';
       debugPrint(message);
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(message)));
-      }
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(message)));
       return;
     }
 
@@ -160,6 +158,7 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
       );
       if (nonce != null) {
         final result = await _createTransaction(nonce, amount);
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(result)),
         );
@@ -167,10 +166,9 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
     } catch (e) {
       final message = 'Apple Pay error: $e';
       debugPrint(message);
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(message)));
-      }
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(message)));
     }
   }
 


### PR DESCRIPTION
## Summary
- add mounted guard clauses before showing SnackBars in Google/Apple Pay flows

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a145f2cc6083319f00451948987ff0