### PR TITLE
Handle invalid error JSON responses

### DIFF
--- a/lib/components/cardplacehokder_widget.dart
+++ b/lib/components/cardplacehokder_widget.dart
@@ -94,9 +94,14 @@ class _CardplacehokderWidgetState extends State<CardplacehokderWidget> {
       return data['message']?.toString() ??
           'Pagamento realizado com sucesso!';
     } else {
-      final err = jsonDecode(response.body) as Map<String, dynamic>;
-      final msg = (err['message'] ?? err['error'] ?? response.body).toString();
-      throw Exception('Erro no pagamento: $msg');
+      try {
+        final err = jsonDecode(response.body) as Map<String, dynamic>;
+        final msg = (err['message'] ?? err['error'] ?? response.body).toString();
+        throw Exception('Erro no pagamento: $msg');
+      } on FormatException {
+        debugPrint('Invalid error response from server: ${response.body}');
+        throw Exception('Invalid error response from server');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Catch malformed JSON error responses and throw a clear exception
- Log unexpected backend error responses for easier debugging

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a145f3f0248331b4d524135f3c11b7