### PR TITLE
chore: lower widget deployment target

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -562,7 +562,7 @@
                                 INFOPLIST_FILE = "Quicky Widget/Info.plist";
                                 INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
                                 INFOPLIST_KEY_NSHumanReadableCopyright = "";
-                                IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+                               IPHONEOS_DEPLOYMENT_TARGET = 15.0;
                                 LD_RUNPATH_SEARCH_PATHS = (
                                         "$(inherited)",
                                         "@executable_path/Frameworks",
@@ -604,7 +604,7 @@
 				INFOPLIST_FILE = "Quicky Widget/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+                           IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -643,7 +643,7 @@
 				INFOPLIST_FILE = "Quicky Widget/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+                           IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary
- lower Quicky Widget deployment target to iOS 15.0

## Testing
- `flutter build ios` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a1bcc0deec83319a5fa5c028454b04