### PR TITLE
Lower widget deployment target to iOS 15

### DIFF
--- a/ios/Quicky Widget/AppIntent.swift
+++ b/ios/Quicky Widget/AppIntent.swift
@@ -8,6 +8,7 @@
 import WidgetKit
 import AppIntents
 
+@available(iOSApplicationExtension 16.0, *)
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Configuration"
     static var description = IntentDescription("This is an example widget.")

--- a/ios/Quicky Widget/Quicky_Widget.swift
+++ b/ios/Quicky Widget/Quicky_Widget.swift
@@ -90,9 +90,3 @@ struct Quicky_Widget: Widget {
         .description("Mostra informações do usuário.")
     }
 }
-
-#Preview(as: .systemSmall) {
-    Quicky_Widget()
-} timeline: {
-    UserEntry(date: .now, displayName: "", photoUrl: nil, saldo: "0", nextTask: "", rating: "")
-}

--- a/ios/Quicky Widget/Quicky_WidgetLiveActivity.swift
+++ b/ios/Quicky Widget/Quicky_WidgetLiveActivity.swift
@@ -9,6 +9,7 @@ import ActivityKit
 import WidgetKit
 import SwiftUI
 
+@available(iOSApplicationExtension 16.1, *)
 struct Quicky_WidgetAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
         // Dynamic stateful properties about your activity go here!
@@ -19,6 +20,7 @@ struct Quicky_WidgetAttributes: ActivityAttributes {
     var name: String
 }
 
+@available(iOSApplicationExtension 16.1, *)
 struct Quicky_WidgetLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: Quicky_WidgetAttributes.self) { context in
@@ -56,12 +58,14 @@ struct Quicky_WidgetLiveActivity: Widget {
     }
 }
 
+@available(iOSApplicationExtension 16.1, *)
 extension Quicky_WidgetAttributes {
     fileprivate static var preview: Quicky_WidgetAttributes {
         Quicky_WidgetAttributes(name: "World")
     }
 }
 
+@available(iOSApplicationExtension 16.1, *)
 extension Quicky_WidgetAttributes.ContentState {
     fileprivate static var smiley: Quicky_WidgetAttributes.ContentState {
         Quicky_WidgetAttributes.ContentState(emoji: "😀")
@@ -70,11 +74,4 @@ extension Quicky_WidgetAttributes.ContentState {
      fileprivate static var starEyes: Quicky_WidgetAttributes.ContentState {
          Quicky_WidgetAttributes.ContentState(emoji: "🤩")
      }
-}
-
-#Preview("Notification", as: .content, using: Quicky_WidgetAttributes.preview) {
-   Quicky_WidgetLiveActivity()
-} contentStates: {
-    Quicky_WidgetAttributes.ContentState.smiley
-    Quicky_WidgetAttributes.ContentState.starEyes
 }

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -562,7 +562,7 @@
                                 INFOPLIST_FILE = "Quicky Widget/Info.plist";
                                 INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
                                 INFOPLIST_KEY_NSHumanReadableCopyright = "";
-                                IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+                                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
                                 LD_RUNPATH_SEARCH_PATHS = (
                                         "$(inherited)",
                                         "@executable_path/Frameworks",
@@ -604,7 +604,7 @@
 				INFOPLIST_FILE = "Quicky Widget/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+                                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -643,7 +643,7 @@
 				INFOPLIST_FILE = "Quicky Widget/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Quicky Widget";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+                                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary
- lower Quicky Widget deployment target to iOS 15
- gate AppIntent and LiveActivity code behind iOS 16 availability and drop SwiftUI preview macros

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1b595c0908331976afcff028805e1