### PR TITLE
fix: remove duplicate main entry from widget

### DIFF
--- a/ios/Quicky Widget/Quicky_Widget.swift
+++ b/ios/Quicky Widget/Quicky_Widget.swift
@@ -116,7 +116,6 @@ struct Quicky_WidgetEntryView: View {
     }
 }
 
-@main
 struct Quicky_Widget: Widget {
     let kind: String = "Quicky_Widget"
 


### PR DESCRIPTION
## Summary
- fix widget extension build by removing duplicate `@main` annotation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a37051c534833180b28b9de1d6f202