### PR TITLE
fix: resolve iOS widget build errors

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -19,7 +19,6 @@ flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks! :linkage => :static
-  use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 

--- a/ios/Quicky Widget/Quicky_Widget.swift
+++ b/ios/Quicky Widget/Quicky_Widget.swift
@@ -116,7 +116,6 @@ struct Quicky_WidgetEntryView: View {
     }
 }
 
-@main
 struct Quicky_Widget: Widget {
     let kind: String = "Quicky_Widget"
 


### PR DESCRIPTION
## Summary
- remove duplicate `@main` annotation from widget so bundle is sole entry point
- drop `use_modular_headers!` from Podfile to avoid non-modular include build failures

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a37051c534833180b28b9de1d6f202