### PR TITLE
chore: patch sign in with apple plugin

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -161,6 +161,12 @@ workflows:
           pod install --verbose
           cd ..
 
+      - name: Patch SignInWithAppleError.swift (temporário)
+        script: |
+          set -euo pipefail
+          perl -0pi -e "s/(\s*)(case \\.notInteractive:)/\\1\\/\\/\\2/; s/(\s*)(case \\.matchedExcludedCredential:)/\\1\\/\\/\\2/" \
+            ios/Pods/sign_in_with_apple/sign_in_with_apple/Sources/sign_in_with_apple/SignInWithAppleError.swift
+
       - name: Importar certificado no keychain (sem interação)
         script: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- patch sign_in_with_apple Swift source during Codemagic build to avoid Xcode compilation error

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a4b183664c8331b3e96022bad9bcd0